### PR TITLE
Fixing wrong CMD file call in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,6 @@ RUN cd /opt/saltpad && \
 ADD ./local_settings.docker /opt/saltpad/saltpad/local_settings.py
 
 EXPOSE 5000
-WORKDIR /opt/saltpad/saltpad
+WORKDIR /opt/saltpad
 
-CMD ["/usr/bin/python","/opt/saltpad/saltpad/app.py"]
+CMD ["/usr/bin/python","/opt/saltpad/run.py"]


### PR DESCRIPTION
With `CMD ["/usr/bin/python","/opt/saltpad/saltpad/app.py"]`

<pre>
╰─➤  docker run -p 5000:5000 saltpad
Traceback (most recent call last):
  File "/opt/saltpad/saltpad/app.py", line 8, in <module>
    from .core import HTTPSaltStackClient, ExpiredToken, Unauthorized
ValueError: Attempted relative import in non-package
</pre>


With `CMD ["/usr/bin/python","/opt/saltpad/run.py"]` instead:

<pre>
╰─➤  docker run -p 5000:5000 saltpad
 * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
 * Restarting with stat
</pre>
